### PR TITLE
Upgrading the Raven/Sentry client to the latest release

### DIFF
--- a/raven/.gitignore
+++ b/raven/.gitignore
@@ -1,0 +1,6 @@
+*.lock
+package.xml
+/vendor
+.idea
+.php_cs.cache
+docs/_build

--- a/raven/.gitmodules
+++ b/raven/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs/_sentryext"]
+	path = docs/_sentryext
+	url = https://github.com/getsentry/sentry-doc-support

--- a/raven/.php_cs
+++ b/raven/.php_cs
@@ -1,0 +1,12 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in(__DIR__)
+;
+
+return Symfony\CS\Config\Config::create()
+    ->setUsingCache(true)
+    ->setUsingLinter(true)
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->finder($finder)
+;

--- a/raven/.travis.yml
+++ b/raven/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
+  fast_finish: true
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - composer self-update
+
+install: travis_retry composer install --no-interaction --prefer-source
+
+script:
+  - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
+  - vendor/bin/phpunit

--- a/raven/AUTHORS
+++ b/raven/AUTHORS
@@ -1,4 +1,4 @@
-The Raven PHP client was originally written by Michael van Tellingen
+The Sentry PHP SDK was originally written by Michael van Tellingen
 and is maintained by the Sentry Team.
 
-http://github.com/getsentry/raven-php/contributors
+http://github.com/getsentry/sentry-php/contributors

--- a/raven/CHANGES
+++ b/raven/CHANGES
@@ -1,3 +1,52 @@
+0.15.0
+------
+
+- Fixed some cases where serialization wouldn't happen.
+- Added sdk attribute.
+
+0.14.0
+------
+
+- Added ``prefixes`` option for stripping absolute paths.
+- Removed ``abs_path`` from stacktraces.
+- Added ``app_path`` to specify application root for resolving ``in_app` on frames.
+- Moved Laravel support to ``sentry-laravel`` project.
+- Fixed duplicate stack computation.
+- Added ``dsn`` option to ease configuration.
+- Fixed an issue with the curl async transport.
+- Improved serialization of values.
+
+0.13.0
+------
+
+- Updated API to use new style interfaces.
+- Remove session cookie in default processor.
+- Expand docs for Laravel, Symfony2, and Monolog.
+- Default error types can now be set as part of ErrorHandler configuration.
+
+0.12.1
+------
+
+- Dont send empty values for various context.
+
+0.12.0
+------
+
+- Bumped protocol version to 6.
+- Fixed an issue with the async curl handler (GH-216).
+- Removed UDP transport.
+
+0.11.0
+------
+
+- New configuration parameter: 'release'
+- New configuration parameter: 'message_limit'
+- New configuration parameter: 'curl_ssl_version'
+- New configuration parameter: 'curl_ipv4'
+- New configuration parameter: 'verify_ssl'
+- Updated remote endpoint to use modern project-based path.
+- Expanded default sanitizer support to include 'auth_pw' attribute.
+
 0.10.0
 ------
 

--- a/raven/LICENSE
+++ b/raven/LICENSE
@@ -7,6 +7,6 @@ Redistribution and use in source and binary forms, with or without modification,
 
     2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
-    3. Neither the name of the Raven nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+    3. Neither the name of the Raven, Sentry, nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/raven/Makefile
+++ b/raven/Makefile
@@ -1,10 +1,20 @@
 .PHONY: test
 
-develop:
+develop: update-submodules
 	composer install --dev
 	make setup-git
 
-test:
+update-submodules:
+	git submodule init
+	git submodule update
+
+cs:
+	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
+
+cs-dry-run:
+	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
+
+test: cs-dry-run
 	vendor/bin/phpunit
 
 setup-git:

--- a/raven/README.rst
+++ b/raven/README.rst
@@ -1,11 +1,11 @@
-raven-php
-=========
+sentry-php
+==========
 
-.. image:: https://secure.travis-ci.org/getsentry/raven-php.png?branch=master
-   :target: http://travis-ci.org/getsentry/raven-php
+.. image:: https://secure.travis-ci.org/getsentry/sentry-php.png?branch=master
+   :target: http://travis-ci.org/getsentry/sentry-php
 
 
-raven-php is a PHP client for `Sentry <http://aboutsentry.com/>`_.
+The official PHP SDK for `Sentry <https://getsentry.com/>`_.
 
 .. code-block:: php
 
@@ -47,27 +47,25 @@ Install with Composer
 If you're using `Composer <https://getcomposer.org/>`_ to manage
 dependencies, you can add Raven with it.
 
-.. code-block:: json
+::
 
-    {
-        "require": {
-            "raven/raven": "$VERSION"
-        }
-    }
+    $ composer require sentry/sentry:$VERSION
 
-(replace ``$VERSION`` with one of the available versions on `Packagist <https://packagist.org/packages/raven/raven>`_)
+(replace ``$VERSION`` with one of the available versions on `Packagist <https://packagist.org/packages/sentry/sentry>`_)
 or to get the latest version off the master branch:
 
-.. code-block:: json
+::
 
-    {
-        "require": {
-            "raven/raven": "dev-master"
-        }
-    }
+    $ composer require sentry/sentry:dev-master
 
 Note that using unstable versions is not recommended and should be avoided. Also
 you should define a maximum version, e.g. by doing ``>=0.6,<1.0`` or ``~0.6``.
+
+Alternatively, use the ``^`` operator for specifying a version, e.g.,
+
+::
+
+    $ composer require sentry/sentry:^0.11.0
 
 Composer will take care of the autoloading for you, so if you require the
 ``vendor/autoload.php``, you're good to go.
@@ -80,7 +78,7 @@ To install the source code:
 
 ::
 
-    $ git clone git://github.com/getsentry/raven-php.git
+    $ git clone git://github.com/getsentry/sentry-php.git
 
 And including it using the autoloader:
 
@@ -97,9 +95,9 @@ the Sentry master server:
 
 .. code-block:: bash
 
-    $ bin/raven test https://public:secret@app.getsentry.com/1
+    $ bin/sentry test https://public:secret@app.getsentry.com/1
     Client configuration:
-    -> servers: [https://sentry.example.com/api/store/]
+    -> server: [https://sentry.example.com/api/store/]
     -> project: 1
     -> public_key: public
     -> secret_key: secret
@@ -262,14 +260,14 @@ You may now use phpunit :
 
 ::
 
-    $ bin/phpunit
+    $ vendor/bin/phpunit
 
 
 
 Resources
 ---------
 
-* `Bug Tracker <http://github.com/getsentry/raven-php/issues>`_
-* `Code <http://github.com/getsentry/raven-php>`_
+* `Bug Tracker <http://github.com/getsentry/sentry-php/issues>`_
+* `Code <http://github.com/getsentry/sentry-php>`_
 * `Mailing List <https://groups.google.com/group/getsentry>`_
 * `IRC <irc://irc.freenode.net/sentry>`_  (irc.freenode.net, #sentry)

--- a/raven/bin/sentry
+++ b/raven/bin/sentry
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 // Maximize error reporting
@@ -35,10 +35,12 @@ function cmd_test($dsn)
     $client = new Raven_Client($dsn, array(
         'trace' => true,
         'curl_method' => 'sync',
+        'app_path' => realpath(__DIR__ . '/..'),
+        'base_path' => realpath(__DIR__ . '/..'),
     ));
 
     $config = get_object_vars($client);
-    $required_keys = array('servers', 'project', 'public_key', 'secret_key');
+    $required_keys = array('server', 'project', 'public_key', 'secret_key');
 
     echo "Client configuration:\n";
     foreach ($required_keys as $key) {

--- a/raven/composer.json
+++ b/raven/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "raven/raven",
+    "name": "sentry/sentry",
     "type": "library",
     "description": "A PHP client for Sentry (http://getsentry.com)",
     "keywords": ["log", "logging"],
     "homepage": "http://getsentry.com",
-    "license": "BSD",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "David Cramer",
@@ -12,17 +12,17 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "fabpot/php-cs-fixer": "^1.8.0",
+        "phpunit/phpunit": "^4.6.6"
     },
     "require": {
-        "php": ">=5.2.4"
+        "php": ">=5.2.4",
+        "ext-curl": "*",
+        "monolog/monolog": "*"
     },
     "bin": [
-        "bin/raven"
+        "bin/sentry"
     ],
-    "config": {
-        "bin-dir": "bin"
-    },
     "autoload": {
         "psr-0" : {
             "Raven_" : "lib/"
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.8.x-dev"
+            "dev-master": "0.17.x-dev"
         }
     }
 }

--- a/raven/lib/Raven/Breadcrumbs.php
+++ b/raven/lib/Raven/Breadcrumbs.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Raven Breadcrumbs
+ *
+ * @package raven
+ */
+
+class Raven_Breadcrumbs
+{
+    public function __construct($size = 100)
+    {
+        $this->count = 0;
+        $this->pos = 0;
+        $this->size = $size;
+        $this->buffer = array();
+    }
+
+    public function record($crumb)
+    {
+        if (empty($crumb['timestamp'])) {
+            $crumb['timestamp'] = microtime(true);
+        }
+        $this->buffer[$this->pos] = $crumb;
+        $this->pos = ($this->pos + 1) % $this->size;
+        $this->count++;
+    }
+
+    public function fetch()
+    {
+        $results = array();
+        for ($i = 0; $i <= ($this->size - 1); $i++) {
+            $node = @$this->buffer[($this->pos + $i) % $this->size];
+
+            if (isset($node)) {
+                $results[] = $node;
+            }
+        }
+        return $results;
+    }
+
+    public function is_empty()
+    {
+        return $this->count === 0;
+    }
+
+    public function to_json()
+    {
+        return array(
+            'values' => $this->fetch(),
+        );
+    }
+}

--- a/raven/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/raven/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -1,0 +1,94 @@
+<?php
+
+use Monolog\Logger;
+use Monolog\Handler\AbstractProcessingHandler;
+
+class Raven_Breadcrumbs_MonologHandler extends AbstractProcessingHandler
+{
+    /**
+     * Translates Monolog log levels to Raven log levels.
+     */
+    private $logLevels = array(
+        Logger::DEBUG     => Raven_Client::DEBUG,
+        Logger::INFO      => Raven_Client::INFO,
+        Logger::NOTICE    => Raven_Client::INFO,
+        Logger::WARNING   => Raven_Client::WARNING,
+        Logger::ERROR     => Raven_Client::ERROR,
+        Logger::CRITICAL  => Raven_Client::FATAL,
+        Logger::ALERT     => Raven_Client::FATAL,
+        Logger::EMERGENCY => Raven_Client::FATAL,
+    );
+
+    private $excMatch = '/^exception \'([^\']+)\' with message \'(.+)\' in .+$/s';
+
+    /**
+     * @var Raven_Client the client object that sends the message to the server
+     */
+    protected $ravenClient;
+
+    /**
+     * @param Raven_Client $ravenClient
+     * @param int          $level       The minimum logging level at which this handler will be triggered
+     * @param Boolean      $bubble      Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(Raven_Client $ravenClient, $level = Logger::DEBUG, $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->ravenClient = $ravenClient;
+    }
+
+    protected function parseException($message)
+    {
+        if (!preg_match($this->excMatch, $message, $matches)) {
+            return;
+        }
+
+        return array($matches[1], $matches[2]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record)
+    {
+        // sentry uses the 'nobreadcrumb' attribute to skip reporting
+        if (!empty($record['context']['nobreadcrumb'])) {
+            return;
+        }
+
+        if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
+            $exc = $record['context']['exception'];
+            $crumb = array(
+                'type' => 'error',
+                'level' => $this->logLevels[$record['level']],
+                'category' => $record['channel'],
+                'data' => array(
+                    'type' => get_class($exc),
+                    'value' => $exc->getMessage(),
+                ),
+            );
+        } else {
+            // TODO(dcramer): parse exceptions out of messages and format as above
+            if ($error = $this->parseException($record['message'])) {
+                $crumb = array(
+                    'type' => 'error',
+                    'level' => $this->logLevels[$record['level']],
+                    'category' => $record['channel'],
+                    'data' => array(
+                        'type' => $error[0],
+                        'value' => $error[1],
+                    ),
+                );
+            } else {
+                $crumb = array(
+                    'level' => $this->logLevels[$record['level']],
+                    'category' => $record['channel'],
+                    'message' => $record['message'],
+                );
+            }
+        }
+
+        $this->ravenClient->breadcrumbs->record($crumb);
+    }
+}

--- a/raven/lib/Raven/Compat.php
+++ b/raven/lib/Raven/Compat.php
@@ -11,7 +11,6 @@
 
 class Raven_Compat
 {
-
     public static function gethostname()
     {
         if (function_exists('gethostname')) {

--- a/raven/lib/Raven/ErrorHandler.php
+++ b/raven/lib/Raven/ErrorHandler.php
@@ -21,6 +21,9 @@
  * @package raven
  */
 
+// TODO(dcramer): deprecate default error types in favor of runtime configuration
+// unless a reason can be determined that making them dynamic is better. They
+// currently are not used outside of the fatal handler.
 class Raven_ErrorHandler
 {
     private $old_exception_handler;
@@ -29,11 +32,60 @@ class Raven_ErrorHandler
     private $call_existing_error_handler = false;
     private $reservedMemory;
     private $send_errors_last = false;
-    private $error_types = -1;
 
-    public function __construct($client, $send_errors_last = false)
+    /**
+     * @var array
+     * Error types which should be processed by the handler.
+     * A 'null' value implies "whatever error_reporting is at time of error".
+     */
+    private $error_types = null;
+
+    /**
+     * @deprecated
+     * @var array
+     * Error types that can be processed by the handler
+     */
+    private $validErrorTypes = array(
+        E_ERROR,
+        E_WARNING,
+        E_PARSE,
+        E_NOTICE,
+        E_CORE_ERROR,
+        E_CORE_WARNING,
+        E_COMPILE_ERROR,
+        E_COMPILE_WARNING,
+        E_USER_ERROR,
+        E_USER_WARNING,
+        E_USER_NOTICE,
+        E_STRICT,
+        E_RECOVERABLE_ERROR,
+        E_DEPRECATED,
+        E_USER_DEPRECATED,
+    );
+
+    /**
+     * @deprecated
+     * @var array
+     * The default Error types that are always processed by the handler. Can be set during construction.
+     */
+    private $defaultErrorTypes = array(
+        E_ERROR,
+        E_PARSE,
+        E_CORE_ERROR,
+        E_CORE_WARNING,
+        E_COMPILE_ERROR,
+        E_COMPILE_WARNING,
+        E_STRICT,
+    );
+
+    public function __construct($client, $send_errors_last = false, $default_error_types = null,
+                                $error_types = null)
     {
         $this->client = $client;
+        if ($default_error_types !== null) {
+            $this->defaultErrorTypes = $default_error_types;
+        }
+        $this->error_types = $error_types;
         register_shutdown_function(array($this, 'detectShutdown'));
         if ($send_errors_last) {
             $this->send_errors_last = true;
@@ -53,14 +105,47 @@ class Raven_ErrorHandler
 
     public function handleError($code, $message, $file = '', $line = 0, $context=array())
     {
-        if ($this->error_types & $code & error_reporting()) {
-          $e = new ErrorException($message, 0, $code, $file, $line);
-          $this->handleException($e, true, $context);
+        if (error_reporting() !== 0) {
+            $error_types = $this->error_types;
+            if ($error_types === null) {
+                $error_types = error_reporting();
+            }
+            if ($error_types & $code) {
+                $e = new ErrorException($message, 0, $code, $file, $line);
+                $this->handleException($e, true, $context);
+            }
         }
+        if ($this->call_existing_error_handler) {
+            if ($this->old_error_handler !== null) {
+                return call_user_func($this->old_error_handler, $code, $message, $file, $line, $context);
+            } else {
+                return false;
+            }
+        }
+    }
 
-        if ($this->call_existing_error_handler && $this->old_error_handler) {
-            call_user_func($this->old_error_handler, $code, $message, $file, $line, $context);
-        }
+    /**
+     * Nothing by default, use it in child classes for catching other types of errors
+     * Only constants from $this->validErrorTypes can be used
+     *
+     * @deprecated
+     * @return array
+     */
+
+    protected function getAdditionalErrorTypesToProcess()
+    {
+        return array();
+    }
+
+    /**
+     * @deprecated
+     * @return array
+     */
+    private function getErrorTypesToProcess()
+    {
+        $additionalErrorTypes = array_intersect($this->getAdditionalErrorTypesToProcess(), $this->validErrorTypes);
+        // array_unique so bitwise "or" operation wouldn't fail if some error type gets repeated
+        return array_unique(array_merge($this->defaultErrorTypes, $additionalErrorTypes));
     }
 
     public function handleFatalError()
@@ -71,7 +156,10 @@ class Raven_ErrorHandler
 
         unset($this->reservedMemory);
 
-        $errors = E_ERROR | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_STRICT;
+        $errors = 0;
+        foreach ($this->getErrorTypesToProcess() as $errorType) {
+            $errors |= $errorType;
+        }
 
         if ($lastError['type'] & $errors) {
             $e = new ErrorException(
@@ -86,13 +174,24 @@ class Raven_ErrorHandler
     {
         $this->old_exception_handler = set_exception_handler(array($this, 'handleException'));
         $this->call_existing_exception_handler = $call_existing_exception_handler;
+        return $this;
     }
 
-    public function registerErrorHandler($call_existing_error_handler = true, $error_types = -1)
+    /**
+     * Register a handler which will intercept standard PHP errors and report them to the
+     * associated Sentry client.
+     *
+     * @return array
+     */
+    //
+    public function registerErrorHandler($call_existing_error_handler = true, $error_types = null)
     {
-        $this->error_types = $error_types;
-        $this->old_error_handler = set_error_handler(array($this, 'handleError'), error_reporting());
+        if ($error_types !== null) {
+            $this->error_types = $error_types;
+        }
+        $this->old_error_handler = set_error_handler(array($this, 'handleError'), E_ALL);
         $this->call_existing_error_handler = $call_existing_error_handler;
+        return $this;
     }
 
     public function registerShutdownFunction($reservedMemorySize = 10)
@@ -100,9 +199,11 @@ class Raven_ErrorHandler
         register_shutdown_function(array($this, 'handleFatalError'));
 
         $this->reservedMemory = str_repeat('x', 1024 * $reservedMemorySize);
+        return $this;
     }
 
-    public function detectShutdown() {
+    public function detectShutdown()
+    {
         if (!defined('RAVEN_CLIENT_END_REACHED')) {
             define('RAVEN_CLIENT_END_REACHED', true);
         }

--- a/raven/lib/Raven/ReprSerializer.php
+++ b/raven/lib/Raven/ReprSerializer.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Serializes a value into a representation that should reasonable suggest
+ * both the type and value, and be serializable into JSON.
+ * @package raven
+ */
+class Raven_ReprSerializer extends Raven_Serializer
+{
+    protected function serializeValue($value)
+    {
+        if ($value === null) {
+            return 'null';
+        } elseif ($value === false) {
+            return 'false';
+        } elseif ($value === true) {
+            return 'true';
+        } elseif (is_float($value) && (int) $value == $value) {
+            return $value.'.0';
+        } elseif (is_integer($value) || is_float($value)) {
+            return (string) $value;
+        } elseif (is_object($value) || gettype($value) == 'object') {
+            return 'Object '.get_class($value);
+        } elseif (is_resource($value)) {
+            return 'Resource '.get_resource_type($value);
+        } elseif (is_array($value)) {
+            return 'Array of length ' . count($value);
+        } else {
+            $value = (string) $value;
+
+            if (function_exists('mb_convert_encoding')) {
+                $value = mb_convert_encoding($value, 'UTF-8', 'auto');
+            }
+
+            return $value;
+        }
+    }
+}

--- a/raven/lib/Raven/Serializer.php
+++ b/raven/lib/Raven/Serializer.php
@@ -30,45 +30,37 @@ class Raven_Serializer
      * Serialize an object (recursively) into something safe for data
      * sanitization and encoding.
      */
-    public static function serialize($value, $max_depth=9, $_depth=0)
+    public function serialize($value, $max_depth=3, $_depth=0)
     {
         if (is_object($value) || is_resource($value)) {
-            return self::serializeValue($value);
+            return $this->serializeValue($value);
         } elseif ($_depth < $max_depth && is_array($value)) {
             $new = array();
             foreach ($value as $k => $v) {
-                $new[self::serializeValue($k)] = self::serialize($v, $max_depth, $_depth + 1);
+                $new[$this->serializeValue($k)] = $this->serialize($v, $max_depth, $_depth + 1);
             }
 
             return $new;
         } else {
-            return self::serializeValue($value);
+            return $this->serializeValue($value);
         }
     }
 
-    public static function serializeValue($value)
+    protected function serializeValue($value)
     {
-        if ($value === null) {
-            return 'null';
-        } elseif ($value === false) {
-            return 'false';
-        } elseif ($value === true) {
-            return 'true';
-        } elseif (is_float($value) && (int) $value == $value) {
-            return $value.'.0';
+        if (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
+            return $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
             return 'Object '.get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {
             return 'Array of length ' . count($value);
-        } elseif (is_integer($value)) {
-            return (integer) $value;
         } else {
             $value = (string) $value;
 
             if (function_exists('mb_convert_encoding')) {
-                $value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+                $value = mb_convert_encoding($value, 'UTF-8', 'auto');
             }
 
             return $value;

--- a/raven/phpunit.xml
+++ b/raven/phpunit.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/raven/test/Raven/Tests/Breadcrumbs/MonologTest.php
+++ b/raven/test/Raven/Tests/Breadcrumbs/MonologTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Raven_Tests_MonologBreadcrumbHandlerTest extends PHPUnit_Framework_TestCase
+{
+    protected function getSampleErrorMessage()
+    {
+        return <<<EOF
+exception 'Exception' with message 'An unhandled exception' in /sentry-laravel/examples/laravel-4.2/app/routes.php:17
+Stack trace:
+#0 [internal function]: {closure}()
+#1 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(5398): call_user_func_array(Object(Closure), Array)
+#2 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(5065): Illuminate\Routing\Route->run(Object(Illuminate\Http\Request))
+#3 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(5053): Illuminate\Routing\Router->dispatchToRoute(Object(Illuminate\Http\Request))
+#4 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(715): Illuminate\Routing\Router->dispatch(Object(Illuminate\Http\Request))
+#5 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(696): Illuminate\Foundation\Application->dispatch(Object(Illuminate\Http\Request))
+#6 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(7825): Illuminate\Foundation\Application->handle(Object(Illuminate\Http\Request), 1, true)
+#7 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(8432): Illuminate\Session\Middleware->handle(Object(Illuminate\Http\Request), 1, true)
+#8 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(8379): Illuminate\Cookie\Queue->handle(Object(Illuminate\Http\Request), 1, true)
+#9 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(11123): Illuminate\Cookie\Guard->handle(Object(Illuminate\Http\Request), 1, true)
+#10 /sentry-laravel/examples/laravel-4.2/bootstrap/compiled.php(657): Stack\StackedHttpKernel->handle(Object(Illuminate\Http\Request))
+#11 /sentry-laravel/examples/laravel-4.2/public/index.php(49): Illuminate\Foundation\Application->run()
+#12 /sentry-laravel/examples/laravel-4.2/server.php(19): require_once('/Users/dcramer/...')
+#13 {main}
+EOF;
+    }
+
+    public function testSimple()
+    {
+        $client = new \Raven_Client();
+        $handler = new \Raven_Breadcrumbs_MonologHandler($client);
+
+        $logger = new Monolog\Logger('sentry');
+        $logger->pushHandler($handler);
+        $logger->addWarning('Foo');
+
+        $crumbs = $client->breadcrumbs->fetch();
+        $this->assertEquals(count($crumbs), 1);
+        $this->assertEquals($crumbs[0]['message'], 'Foo');
+        $this->assertEquals($crumbs[0]['category'], 'sentry');
+        $this->assertEquals($crumbs[0]['level'], 'warning');
+    }
+
+    public function testErrorInMessage()
+    {
+        $client = new \Raven_Client();
+        $handler = new \Raven_Breadcrumbs_MonologHandler($client);
+
+        $logger = new Monolog\Logger('sentry');
+        $logger->pushHandler($handler);
+        $logger->addError($this->getSampleErrorMessage());
+
+        $crumbs = $client->breadcrumbs->fetch();
+        $this->assertEquals(count($crumbs), 1);
+        $this->assertEquals($crumbs[0]['data']['type'], 'Exception');
+        $this->assertEquals($crumbs[0]['data']['value'], 'An unhandled exception');
+        $this->assertEquals($crumbs[0]['category'], 'sentry');
+        $this->assertEquals($crumbs[0]['level'], 'error');
+    }
+}

--- a/raven/test/Raven/Tests/BreadcrumbsTest.php
+++ b/raven/test/Raven/Tests/BreadcrumbsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Raven_Tests_BreadcrumbsTest extends PHPUnit_Framework_TestCase
+{
+    public function testBuffer()
+    {
+        $breadcrumbs = new Raven_Breadcrumbs(10);
+        for ($i = 0; $i <= 10; $i++) {
+            $breadcrumbs->record(array('message' => $i));
+        }
+
+        $results = $breadcrumbs->fetch();
+
+        $this->assertEquals(count($results), 10);
+        for ($i = 1; $i <= 10; $i++) {
+            $this->assertEquals($results[$i - 1]['message'], $i);
+        }
+    }
+
+    public function testJson()
+    {
+        $breadcrumbs = new Raven_Breadcrumbs(1);
+        $breadcrumbs->record(array('message' => 'test'));
+        $json = $breadcrumbs->to_json();
+
+        $this->assertEquals(count($json['values']), 1);
+        $this->assertEquals($json['values'][0]['message'], 'test');
+    }
+}

--- a/raven/test/Raven/Tests/ErrorHandlerTest.php
+++ b/raven/test/Raven/Tests/ErrorHandlerTest.php
@@ -16,21 +16,30 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->errorLevel = error_reporting();
+        $this->errorHandlerCalled = false;
+        $this->existingErrorHandler = set_error_handler(array($this, 'errorHandler'), -1);
+    }
+
+    public function errorHandler()
+    {
+        $this->errorHandlerCalled = true;
     }
 
     public function tearDown()
     {
+        // XXX(dcramer): this isn't great as it doesnt restore the old error reporting level
+        set_error_handler(array($this, 'errorHandler'), error_reporting());
         error_reporting($this->errorLevel);
     }
 
     public function testErrorsAreLoggedAsExceptions()
     {
-        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client = $this->getMock('Client', array('captureException', 'getIdent', 'sendUnsentErrors'));
         $client->expects($this->once())
                ->method('captureException')
                ->with($this->isInstanceOf('ErrorException'));
 
-        $handler = new Raven_ErrorHandler($client);
+        $handler = new Raven_ErrorHandler($client, E_ALL);
         $handler->handleError(E_WARNING, 'message');
     }
 
@@ -47,31 +56,6 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
         $handler->handleException($e);
     }
 
-    public function testErrorHandlerCheckSilentReporting()
-    {
-        $client = $this->getMock('Client', array('captureException', 'getIdent'));
-        $client->expects($this->never())
-               ->method('captureException');
-
-        $handler = new Raven_ErrorHandler($client);
-        $handler->registerErrorHandler(false);
-
-        @trigger_error('Silent', E_USER_WARNING);
-    }
-
-    public function testErrorHandlerBlockErrorReporting()
-    {
-        $client = $this->getMock('Client', array('captureException', 'getIdent'));
-        $client->expects($this->never())
-               ->method('captureException');
-
-        $handler = new Raven_ErrorHandler($client);
-        $handler->registerErrorHandler(false);
-
-        error_reporting(E_USER_ERROR);
-        trigger_error('Warning', E_USER_WARNING);
-    }
-
     public function testErrorHandlerPassErrorReportingPass()
     {
         $client = $this->getMock('Client', array('captureException', 'getIdent'));
@@ -79,9 +63,85 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
                ->method('captureException');
 
         $handler = new Raven_ErrorHandler($client);
-        $handler->registerErrorHandler(false);
+        $handler->registerErrorHandler(false, -1);
 
         error_reporting(E_USER_WARNING);
         trigger_error('Warning', E_USER_WARNING);
+    }
+
+    public function testErrorHandlerPropagates()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->never())
+               ->method('captureException');
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(true, E_DEPRECATED);
+
+        error_reporting(E_USER_WARNING);
+        trigger_error('Warning', E_USER_WARNING);
+
+        $this->assertEquals($this->errorHandlerCalled, 1);
+    }
+
+    public function testErrorHandlerRespectsErrorReportingDefault()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->once())
+               ->method('captureException');
+
+        error_reporting(E_DEPRECATED);
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(true);
+
+        error_reporting(E_ALL);
+        trigger_error('Warning', E_USER_WARNING);
+
+        $this->assertEquals($this->errorHandlerCalled, 1);
+    }
+
+    // Because we cannot **know** that a user silenced an error, we always
+    // defer to respecting the error reporting settings.
+    public function testSilentErrorsAreReported()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->never())
+               ->method('captureException');
+
+        error_reporting(E_USER_WARNING);
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(false);
+
+        @trigger_error('Silent', E_USER_WARNING);
+    }
+
+    public function testErrorHandlerDefaultsErrorReporting()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->never())
+               ->method('captureException');
+
+        error_reporting(E_USER_ERROR);
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(false);
+
+        trigger_error('Warning', E_USER_WARNING);
+    }
+
+    public function testFluidInterface()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $handler = new Raven_ErrorHandler($client);
+        $result = $handler->registerErrorHandler();
+        $this->assertEquals($result, $handler);
+        $result = $handler->registerExceptionHandler();
+        $this->assertEquals($result, $handler);
+        // TODO(dcramer): cant find a great way to test resetting the shutdown
+        // handler
+        // $result = $handler->registerShutdownHandler();
+        // $this->assertEquals($result, $handler);
     }
 }

--- a/raven/test/Raven/Tests/ReprSerializerTest.php
+++ b/raven/test/Raven/Tests/ReprSerializerTest.php
@@ -9,16 +9,11 @@
  * file that was distributed with this source code.
  */
 
-class Raven_SerializerTestObject
-{
-    private $foo = 'bar';
-}
-
-class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_ReprSerializerTest extends PHPUnit_Framework_TestCase
 {
     public function testArraysAreArrays()
     {
-        $serializer = new Raven_Serializer();
+        $serializer = new Raven_ReprSerializer();
         $input = array(1, 2, 3);
         $result = $serializer->serialize($input);
         $this->assertEquals(array('1', '2', '3'), $result);
@@ -26,7 +21,7 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
 
     public function testObjectsAreStrings()
     {
-        $serializer = new Raven_Serializer();
+        $serializer = new Raven_ReprSerializer();
         $input = new Raven_StacktraceTestObject();
         $result = $serializer->serialize($input);
         $this->assertEquals('Object Raven_StacktraceTestObject', $result);
@@ -34,48 +29,48 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
 
     public function testIntsAreInts()
     {
-        $serializer = new Raven_Serializer();
+        $serializer = new Raven_ReprSerializer();
         $input = 1;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_integer($result));
+        $this->assertTrue(is_string($result));
         $this->assertEquals(1, $result);
     }
 
     public function testFloats()
     {
-        $serializer = new Raven_Serializer();
+        $serializer = new Raven_ReprSerializer();
         $input = 1.5;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_float($result));
-        $this->assertEquals(1.5, $result);
+        $this->assertTrue(is_string($result));
+        $this->assertEquals('1.5', $result);
     }
 
     public function testBooleans()
     {
-        $serializer = new Raven_Serializer();
+        $serializer = new Raven_ReprSerializer();
         $input = true;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_bool($result));
-        $this->assertEquals(true, $result);
+        $this->assertTrue(is_string($result));
+        $this->assertEquals('true', $result);
 
         $input = false;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_bool($result));
-        $this->assertEquals(false, $result);
+        $this->assertTrue(is_string($result));
+        $this->assertEquals('false', $result);
     }
 
     public function testNull()
     {
-        $serializer = new Raven_Serializer();
+        $serializer = new Raven_ReprSerializer();
         $input = null;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_null($result));
-        $this->assertEquals(null, $result);
+        $this->assertTrue(is_string($result));
+        $this->assertEquals('null', $result);
     }
 
     public function testRecursionMaxDepth()
     {
-        $serializer = new Raven_Serializer();
+        $serializer = new Raven_ReprSerializer();
         $input = array();
         $input[] = &$input;
         $result = $serializer->serialize($input, 3);

--- a/raven/test/Raven/Tests/SanitizeDataProcessorTest.php
+++ b/raven/test/Raven/Tests/SanitizeDataProcessorTest.php
@@ -14,7 +14,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
     public function testDoesFilterHttpData()
     {
         $data = array(
-            'sentry.interfaces.Http' => array(
+            'request' => array(
                 'data' => array(
                     'foo' => 'bar',
                     'password' => 'hello',
@@ -36,7 +36,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         $processor = new Raven_SanitizeDataProcessor($client);
         $processor->process($data);
 
-        $vars = $data['sentry.interfaces.Http']['data'];
+        $vars = $data['request']['data'];
         $this->assertEquals($vars['foo'], 'bar');
         $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['password']);
         $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['the_secret']);
@@ -47,6 +47,24 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Array scrubbing has not been implemented yet.');
 
         $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['card_number']['0']);
+    }
+
+    public function testDoesFilterSessionId()
+    {
+        $data = array(
+            'request' => array(
+                'cookies' => array(
+                    ini_get('session.name') => 'abc',
+                ),
+            )
+        );
+
+        $client = new Raven_Client();
+        $processor = new Raven_SanitizeDataProcessor($client);
+        $processor->process($data);
+
+        $cookies = $data['request']['cookies'];
+        $this->assertEquals($cookies[ini_get('session.name')], Raven_SanitizeDataProcessor::MASK);
     }
 
     public function testDoesFilterCreditCard()
@@ -66,12 +84,13 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      * @covers setProcessorOptions
      *
      */
-    public function testSettingProcessorOptions(){
+    public function testSettingProcessorOptions()
+    {
         $client     = new Raven_Client();
         $processor  = new Raven_SanitizeDataProcessor($client);
 
-        $this->assertEquals($processor->getFieldsRe(), '/(authorization|password|passwd|secret|password_confirmation|card_number)/i','got default fields');
-        $this->assertEquals($processor->getValuesRe(),'/^(?:\d[ -]*?){13,16}$/','got default values');
+        $this->assertEquals($processor->getFieldsRe(), '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i', 'got default fields');
+        $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){13,16}$/', 'got default values');
 
         $options = array(
             'fields_re' => '/(api_token)/i',
@@ -80,8 +99,8 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
 
         $processor->setProcessorOptions($options);
 
-        $this->assertEquals($processor->getFieldsRe(), '/(api_token)/i','overwrote fields');
-        $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){15,16}$/','overwrote values');
+        $this->assertEquals($processor->getFieldsRe(), '/(api_token)/i', 'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){15,16}$/', 'overwrote values');
     }
 
     /**
@@ -91,13 +110,14 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      * @param $client_options
      * @param $dsn
      */
-    public function testOverrideOptions($processorOptions, $client_options, $dsn){
+    public function testOverrideOptions($processorOptions, $client_options, $dsn)
+    {
         $client = new Raven_Client($dsn, $client_options);
         $processor = $client->processors[0];
 
         $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
-        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'],'overwrote fields');
-        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'],'overwrote values');
+        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'], 'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'], 'overwrote values');
     }
 
     /**
@@ -108,9 +128,10 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      * @param $client_options
      * @param $dsn
      */
-    public function testOverridenSanitize($processorOptions, $client_options, $dsn){
+    public function testOverridenSanitize($processorOptions, $client_options, $dsn)
+    {
         $data = array(
-            'sentry.interfaces.Http' => array(
+            'request' => array(
                 'data' => array(
                     'foo'               => 'bar',
                     'password'          => 'hello',
@@ -131,22 +152,22 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         $processor = $client->processors[0];
 
         $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
-        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'],'overwrote fields');
-        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'],'overwrote values');
+        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'], 'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'], 'overwrote values');
 
         $processor->process($data);
 
-        $vars = $data['sentry.interfaces.Http']['data'];
-        $this->assertEquals($vars['foo'], 'bar','did not alter foo');
-        $this->assertEquals($vars['password'], 'hello','did not alter password');
-        $this->assertEquals($vars['the_secret'],'hello','did not alter the_secret');
-        $this->assertEquals($vars['a_password_here'],'hello','did not alter a_password_here');
-        $this->assertEquals($vars['mypasswd'],'hello','did not alter mypasswd');
-        $this->assertEquals($vars['authorization'],'Basic dXNlcm5hbWU6cGFzc3dvcmQ=','did not alter authorization');
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['api_token'],'masked api_token');
+        $vars = $data['request']['data'];
+        $this->assertEquals($vars['foo'], 'bar', 'did not alter foo');
+        $this->assertEquals($vars['password'], 'hello', 'did not alter password');
+        $this->assertEquals($vars['the_secret'], 'hello', 'did not alter the_secret');
+        $this->assertEquals($vars['a_password_here'], 'hello', 'did not alter a_password_here');
+        $this->assertEquals($vars['mypasswd'], 'hello', 'did not alter mypasswd');
+        $this->assertEquals($vars['authorization'], 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'did not alter authorization');
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['api_token'], 'masked api_token');
 
         $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['card_number']['0'], 'masked card_number[0]');
-        $this->assertEquals($vars['card_number']['1'], $vars['card_number']['1'],'did not alter card_number[1]');
+        $this->assertEquals($vars['card_number']['1'], $vars['card_number']['1'], 'did not alter card_number[1]');
     }
 
     /**
@@ -154,7 +175,8 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public static function overrideDataProvider(){
+    public static function overrideDataProvider()
+    {
         $processorOptions = array(
             'Raven_SanitizeDataProcessor' => array(
                 'fields_re' => '/(api_token)/i',


### PR DESCRIPTION
https://github.com/getsentry/raven-php has been deprecated in favor of
https://github.com/getsentry/sentry-php

This patch upgrades the vendored Raven/Sentry client.

Of course, the "real" and sane fix for this would be using composer, but
it seems Wordpress is not quite there yet, sadly...
(see http://core.trac.wordpress.org/ticket/23912)